### PR TITLE
Switch dependencies to hosts who serve over HTTPS

### DIFF
--- a/index.php
+++ b/index.php
@@ -196,7 +196,7 @@ $opcache = OpCacheService::init();
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>OPcache statistics on <?php echo $opcache->getData('version', 'host'); ?></title>
     <script src="//cdn.jsdelivr.net/react/0.12.2/react.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
     <style type="text/css">
         body { font-family:sans-serif; font-size:90%; padding: 0; margin: 0 }
         nav { padding-top: 20px; }

--- a/index.php
+++ b/index.php
@@ -195,8 +195,8 @@ $opcache = OpCacheService::init();
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>OPcache statistics on <?php echo $opcache->getData('version', 'host'); ?></title>
-    <script src="http://fb.me/react-0.12.2.min.js"></script>
-    <script src="http://code.jquery.com/jquery-2.1.3.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/0.12.2/react.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <style type="text/css">
         body { font-family:sans-serif; font-size:90%; padding: 0; margin: 0 }
         nav { padding-top: 20px; }


### PR DESCRIPTION
If the page is used in an application that's hosted over HTTPS, browsers throw fits about the JavaScript files getting loaded over HTTP. jquery.com doesn't have an HTTPS solution, and one wasn't obvious for fb.me, so I switched to two well-known hosts that do offer HTTPS.

I kept the version numbers the same.