### PR TITLE
Depend on Zend Opcache extension instead of PHP 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "PHP": ">=5.5.0"
+    "ext-Zend-OPcache": "*"
   }
 }
 


### PR DESCRIPTION
Technically the library should depend on the Zend Opcache extension being present and not PHP 5.5+.

My company's application has a minimum dependency of PHP 5.4+, so many clients are on 5.4. We then recommend that they install the Opcache extension separately. With PHP 5.5 as a requirement the Composer install fails, even though they have Opcache installed.

I tested my change with the following:

Version | Opcache | Outcome
---------- | ------------ | -------------
5.4 | No | Failed
5.4 | Yes | Succeeded
5.6 | Yes | Succeeded