### PR TITLE
Use strict comparisons when testing for settings with no value. Fixes #16

### DIFF
--- a/index.php
+++ b/index.php
@@ -640,7 +640,7 @@ $opcache = OpCacheService::init($options);
                 var vShow;
                 if (directive.v === true || directive.v === false) {
                     vShow = React.createElement('i', {}, directive.v.toString());
-                } else if (directive.v == '') {
+                } else if (directive.v === '') {
                     vShow = React.createElement('i', {}, 'no value');
                 } else {
                     vShow = directive.v;

--- a/src/status.jsx
+++ b/src/status.jsx
@@ -123,7 +123,7 @@ var Directives = React.createClass({
             var vShow;
             if (directive.v === true || directive.v === false) {
                 vShow = React.createElement('i', {}, directive.v.toString());
-            } else if (directive.v == '') {
+            } else if (directive.v === '') {
                 vShow = React.createElement('i', {}, 'no value');
             } else {
                 vShow = directive.v;


### PR DESCRIPTION
Certain OPcache settings, such as `opcache.revalidate_freq`, are integers for which can make sense if they equal zero. However, the OPcache GUI currently shows "no value" instead of "0" if the integer value is zero. I've made issue #16 to address this.

This change fixes the problem.