### PR TITLE
Allow for the Opcache GUI to be autoloaded via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
   "require": {
     "ext-Zend-OPcache": "*",
     "php": ">=5.4"
+  },
+  "autoload": {
+    "psr-4" : {
+      "OpcacheGui\\" : "/"
+    }
   }
 }
 

--- a/index.php
+++ b/index.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace OpcacheGui;
+
 /**
  * OPcache GUI
  *


### PR DESCRIPTION
Currently, you can use Composer to install the `index.php` file in to your `/vendor` directory, but it can't be autoloaded by an more complex application or framework without using `require_once()`, which isn't ideal.

I've added namespacing to the class, and tagged it for autoload. This now allows for things like this (this example is in Laravel:)

```
Route::get('opcache', function() {
    \OpcacheGui\OpCacheService::init();
});
```