### PR TITLE
Added docblock to the top of the file

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * OPcache GUI - build module
+ *
+ * @author Andrew Collington, andy@amnuts.com
+ * @version 3.0.0
+ * @link https://github.com/amnuts/opcache-gui
+ * @license MIT, http://acollington.mit-license.org/
+ */
 
 $parentPath = dirname(__DIR__);
 


### PR DESCRIPTION
There were 3 PHPDocumentor errors in master.
This fixes one of them.
The other two are due to known limitations in PHPDocumentor in dealing with some features of PHP7 type hinting, so can't be fixed until PHPDocumentor actually release their version 3 :-)