### PR TITLE
JIT isn't available in PHP <8.0

### DIFF
--- a/index.php
+++ b/index.php
@@ -496,7 +496,7 @@ class Service
     protected function jitState(array $status, array $directives): array
     {
         $state = [
-            'enabled' => $status['jit']['enabled'],
+            'enabled' => $status['jit']['enabled'] ?? null,
             'reason' => ''
         ];
 


### PR DESCRIPTION
JIT isn't available in PHP <8.0 and accessing the `jit` key in `$status` results in a Notice:
```
Notice: Undefined index: jit in /path/opcache-gui/index.php on line 499

Notice: Trying to access array offset on value of type null in /path/opcache-gui/index.php on line 499
```
The code handles this scenario, we just need to squash the lack of the key causing the notice.

Fixes #114