### PR TITLE
Added default value of Optimization Level

### DIFF
--- a/src/Opcache/Service.php
+++ b/src/Opcache/Service.php
@@ -386,6 +386,9 @@ class Service
                 $v = $this->size($v) . " ({$v})";
             } elseif ($k === 'opcache.optimization_level') {
                 $levels = [];
+                if ($v > 0) {
+                    $levels[] = sprintf("Optimization Level: [0x%08X]", $v);
+                }
                 foreach ($this->optimizationLevels as $level => $info) {
                     if ($level & $v) {
                         $levels[] = "{$info} [{$level}]";


### PR DESCRIPTION
Hi,

I have added the default value of `opcache.optimization_level`.

If the Optimization level is different than 0,  in `phpinfo` you see the value of all optimization levels e.g. **0x7FFEBFFF**. This value is missing in opcache-gui

<img width="554" height="28" alt="image" src="https://github.com/user-attachments/assets/f59b4451-5d0b-46ad-9232-718a5d26d50b" />

As you can see, the `Optimization Level: [0x7FFEBFFF]` has been added in the first place

<img width="641" height="485" alt="image" src="https://github.com/user-attachments/assets/638a2518-5dd4-4608-9ebf-b8d06dbc5fe0" />
